### PR TITLE
Auto-Scan the Controllers Directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,14 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     protected $scanWhenLocal = false;
 
+    /**
+     * Determines whether or not to automatically scan the controllers
+     * directory (App\Http\Controllers) for routes
+     *
+     * @var bool
+     */
+    protected $scanControllers = false;
+
 }
 ```
 
@@ -221,5 +229,58 @@ class AuthController extends Controller {
     return redirect( route('login') );
   }
 
+}
+
+```
+
+#### Scan the Controllers Directory
+
+To recursively scan the entire controllers namespace ( `App\Http\Controllers` ), you can set the `$scanControllers` flag to true.
+
+It will automatically adjust `App` to your app's namespace.
+
+```php
+    $scanControllers = true;
+```
+
+### Advanced
+
+If you want to use any logic to add classes to the list to scan, you can override the `routeScans()` or `eventScans()` methods.
+
+The following is an example of adding a controller to the scan list if the current environment is `local`:
+
+```php
+public function routeScans() {
+    $classes = parent::routeScans();
+
+    if ( $this->app->environment('local') ) {
+        $classes = array_merge($classes, ['App\\Http\\Controllers\\LocalOnlyController']);
+    }
+
+    return $classes;
+}
+```
+
+#### Scanning Namespaces
+
+You can use the `getClassesFromNamespace( $namespace )` method to recursively add namespaces to the list. This will scan the given namespace. It only works for classes in the `app` directory, and relies on the PSR-4 namespacing standard.
+
+This is what the `$scanControllers` flag uses with the controllers directory.
+
+Here is an example that builds on the last one - adding a whole local-only namespace.
+
+```php
+public function routeScans() {
+    $classes = parent::routeScans();
+
+    if ( $this->app->environment('local') ) {
+    {
+        $classes = array_merge(
+            $classes,
+            $this->getClassesFromNamespace( 'App\\Http\\Controllers\\Local' )
+        );
+    }
+
+    return $classes;
 }
 ```

--- a/src/AnnotationsServiceProvider.php
+++ b/src/AnnotationsServiceProvider.php
@@ -2,12 +2,15 @@
 
 use Collective\Annotations\Console\EventScanCommand;
 use Collective\Annotations\Console\RouteScanCommand;
+use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Collective\Annotations\Events\Annotations\Scanner as EventScanner;
 use Collective\Annotations\Routing\Annotations\Scanner as RouteScanner;
 
 class AnnotationsServiceProvider extends ServiceProvider {
+
+    use AppNamespaceDetectorTrait;
 
     /**
      * The commands to be registered.
@@ -39,6 +42,14 @@ class AnnotationsServiceProvider extends ServiceProvider {
      * @var bool
      */
     protected $scanWhenLocal = false;
+
+    /**
+     * Determines whether or not to automatically scan the controllers
+     * directory (App\Http\Controllers) for routes
+     *
+     * @var bool
+     */
+    protected $scanControllers = false;
 
     /**
      * File finder for annotations.
@@ -241,6 +252,53 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     public function routeScans()
     {
-        return $this->scanRoutes;
+        $classes = $this->scanRoutes;
+
+        // scan the controllers namespace if the flag is set
+        if ( $this->scanControllers )
+        {
+            $classes = array_merge(
+                $classes,
+                $this->getClassesFromNamespace( $this->getAppNamespace() . 'Http\\Controllers' )
+            );
+        }
+
+        return $classes;
+
     }
+
+    /**
+     * Convert the given namespace to a file path
+     *
+     * @param  string $namespace the namespace to convert
+     * @return string
+     */
+    public function convertNamespaceToPath( $namespace )
+    {
+        // remove the app namespace from the namespace if it is there
+        $appNamespace = $this->getAppNamespace();
+
+        if (substr($namespace, 0, strlen($appNamespace)) == $appNamespace)
+        {
+            $namespace = substr($namespace, strlen($appNamespace));
+        }
+
+        // trim and return the path
+        return str_replace('\\', '/', trim($namespace, ' \\') );
+    }
+
+    /**
+     * Get a list of the classes in a namespace. Leaving the second argument
+     * will scan for classes within the project's app directory
+     *
+     * @param  string $namespace the namespace to search
+     * @return array
+     */
+    public function getClassesFromNamespace( $namespace, $base = null )
+    {
+        $directory = ( $base ?: $this->app->make('path') ) . '/' . $this->convertNamespaceToPath( $namespace );
+
+        return $this->app->make('Illuminate\Filesystem\ClassFinder')->findClasses( $directory );
+    }
+
 }

--- a/src/AnnotationsServiceProvider.php
+++ b/src/AnnotationsServiceProvider.php
@@ -146,7 +146,9 @@ class AnnotationsServiceProvider extends ServiceProvider {
             $this->scanEvents();
         }
 
-        if ( ! empty($this->eventScans()) && $this->finder->eventsAreScanned())
+        $scans = $this->eventScans();
+
+        if ( ! empty($scans) && $this->finder->eventsAreScanned())
         {
             $this->loadScannedEvents();
         }
@@ -159,12 +161,14 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     protected function scanEvents()
     {
-        if (empty($this->eventScans()))
+        $scans = $this->eventScans();
+
+        if (empty($scans))
         {
             return;
         }
 
-        $scanner = new EventScanner($this->eventScans());
+        $scanner = new EventScanner($scans);
 
         file_put_contents(
           $this->finder->getScannedEventsPath(), '<?php ' . $scanner->getEventDefinitions()
@@ -195,7 +199,9 @@ class AnnotationsServiceProvider extends ServiceProvider {
             $this->scanRoutes();
         }
 
-        if ( ! empty($this->routeScans()) && $this->finder->routesAreScanned())
+        $scans = $this->routeScans();
+
+        if ( ! empty($scans) && $this->finder->routesAreScanned())
         {
             $this->loadScannedRoutes();
         }
@@ -208,12 +214,14 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     protected function scanRoutes()
     {
-        if (empty($this->routeScans()))
+        $scans = $this->routeScans();
+
+        if (empty($scans))
         {
             return;
         }
 
-        $scanner = new RouteScanner($this->routeScans());
+        $scanner = new RouteScanner($scans);
 
         file_put_contents(
           $this->finder->getScannedRoutesPath(), '<?php ' . $scanner->getRouteDefinitions()

--- a/src/AnnotationsServiceProvider.php
+++ b/src/AnnotationsServiceProvider.php
@@ -135,7 +135,7 @@ class AnnotationsServiceProvider extends ServiceProvider {
             $this->scanEvents();
         }
 
-        if ( ! empty($this->scanEvents) && $this->finder->eventsAreScanned())
+        if ( ! empty($this->eventScans()) && $this->finder->eventsAreScanned())
         {
             $this->loadScannedEvents();
         }
@@ -148,12 +148,12 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     protected function scanEvents()
     {
-        if (empty($this->scanEvents))
+        if (empty($this->eventScans()))
         {
             return;
         }
 
-        $scanner = new EventScanner($this->scanEvents);
+        $scanner = new EventScanner($this->eventScans());
 
         file_put_contents(
           $this->finder->getScannedEventsPath(), '<?php ' . $scanner->getEventDefinitions()
@@ -184,7 +184,7 @@ class AnnotationsServiceProvider extends ServiceProvider {
             $this->scanRoutes();
         }
 
-        if ( ! empty($this->scanRoutes) && $this->finder->routesAreScanned())
+        if ( ! empty($this->routeScans()) && $this->finder->routesAreScanned())
         {
             $this->loadScannedRoutes();
         }
@@ -197,12 +197,12 @@ class AnnotationsServiceProvider extends ServiceProvider {
      */
     protected function scanRoutes()
     {
-        if (empty($this->scanRoutes))
+        if (empty($this->routeScans()))
         {
             return;
         }
 
-        $scanner = new RouteScanner($this->scanRoutes);
+        $scanner = new RouteScanner($this->routeScans());
 
         file_put_contents(
           $this->finder->getScannedRoutesPath(), '<?php ' . $scanner->getRouteDefinitions()

--- a/tests/AnnotationsServiceProviderTest.php
+++ b/tests/AnnotationsServiceProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Mockery as m;
+use Collective\Annotations\AnnotationsServiceProvider;
+
+class AnnotationsServiceProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp()
+	{
+		$this->app = m::mock('Illuminate\Contracts\Foundation\Application');
+		$this->provider = new AnnotationsServiceProvider( $this->app );
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testConvertNamespaceToPath()
+	{
+		$this->provider = new AnnotationsServiceProviderAppNamespaceStub( $this->app );
+		$class = 'App\\Foo';
+
+		$result = $this->provider->convertNamespaceToPath($class);
+
+		$this->assertEquals('Foo', $result);
+	}
+
+	public function testConvertNamespaceToPathWithoutRootNamespace()
+	{
+		$this->provider = new AnnotationsServiceProviderAppNamespaceStub( $this->app );
+		$this->provider->appNamespace = 'Foo';
+		$class = 'App\\Foo';
+
+		$result = $this->provider->convertNamespaceToPath($class);
+
+		$this->assertEquals('App/Foo', $result);
+	}
+
+	public function testGetClassesFromNamespace()
+	{
+		$this->provider = new AnnotationsServiceProviderAppNamespaceStub( $this->app );
+		$this->provider->appNamespace = 'App';
+
+		$this->app->shouldReceive( 'make' )
+			->with( 'Illuminate\Filesystem\ClassFinder' )->once()
+			->andReturn( $classFinder = m::mock() );
+
+		$classFinder->shouldReceive('findClasses')
+			->with('path/to/app/Base')->once()
+			->andReturn( ['classes'] );
+
+		$results = $this->provider->getClassesFromNamespace( 'App\\Base', 'path/to/app' );
+
+		$this->assertEquals( ['classes'], $results );
+	}
+}
+
+
+class AnnotationsServiceProviderAppNamespaceStub extends AnnotationsServiceProvider {
+	public $appNamespace = 'App';
+
+	public function getAppNamespace()
+	{
+		return $this->appNamespace;
+	}
+}


### PR DESCRIPTION
Sorry this took so long to re-submit [this](https://github.com/adamgoose/laravel-annotations/pull/7) to this repo!

This adds a flag (`$scanControllers`) to the service provider that - when set to true, recursively scans the default controllers directory (`App\Http\Controllers`).

I have added notes on this to the readme.

Unit tests included.

Doesn't break backwards compatability.
