### PR TITLE
Allow binding to models that extend Eloquent at any point, not just their immediate parent

### DIFF
--- a/src/Database/Eloquent/Annotations/Scanner.php
+++ b/src/Database/Eloquent/Annotations/Scanner.php
@@ -61,7 +61,7 @@ class Scanner extends AnnotationScanner {
      */
     protected function extendsEloquent(ReflectionClass $class)
     {
-        return $class->getParentClass() && $class->getParentClass()->name == 'Illuminate\Database\Eloquent\Model';
+        return $class->isSubclassOf('Illuminate\Database\Eloquent\Model');
     }
 
     /**


### PR DESCRIPTION
This allows binding to models which are a distant subclass of Eloquent, such as MongoDB, Sentry, etc.
