### PR TITLE
Add custom resolution method to @Bind annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "~5.0",
         "doctrine/annotations": "~1.0",
         "symfony/console": "2.6.*",
-        "symfony/finder": "2.6.*"
+        "symfony/finder": "2.7.*"
     },
     "require-dev": {
         "illuminate/database": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/console": "~5.0",
-        "illuminate/filesystem": "~5.0",
-        "illuminate/support": "~5.0",
+        "php": ">=5.5.9",
+        "illuminate/console": "5.1.*",
+        "illuminate/filesystem": "5.1.*",
+        "illuminate/support": "5.1.*",
         "doctrine/annotations": "~1.0",
-        "symfony/console": "2.6.*",
+        "symfony/console": "2.7.*",
         "symfony/finder": "2.7.*"
     },
     "require-dev": {
-        "illuminate/database": "~5.0",
+        "illuminate/database": "5.1.*",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },

--- a/src/Database/Eloquent/Annotations/Annotations/Bind.php
+++ b/src/Database/Eloquent/Annotations/Annotations/Bind.php
@@ -8,9 +8,16 @@ class Bind {
     /**
      * The binding the annotation binds the model to.
      *
-     * @var array
+     * @var string
      */
     public $binding;
+
+    /**
+     * Optional class (and method) used to resolve the model instance.
+     *
+     * @var string
+     */
+    public $binder = null;
 
     /**
      * Create a new annotation instance.
@@ -21,6 +28,9 @@ class Bind {
     public function __construct(array $values = array())
     {
         $this->binding = $values['value'];
+        if (isset($values['uses'])) {
+            $this->binder = $values['uses'];
+        }
     }
 
 }

--- a/src/Database/Eloquent/Annotations/Scanner.php
+++ b/src/Database/Eloquent/Annotations/Scanner.php
@@ -47,7 +47,7 @@ class Scanner extends AnnotationScanner {
 
             foreach ($annotations as $annotation)
             {
-                $output .= $this->buildBinding($annotation->binding, $class->name);
+                $output .= $this->buildBinding($annotation, $class->name);
             }
         }
 
@@ -69,13 +69,20 @@ class Scanner extends AnnotationScanner {
     /**
      * Build the event listener for the class and method.
      *
-     * @param  string $binding
+     * @param  Bind   $annotation
      * @param  string $class
      *
      * @return string
      */
-    protected function buildBinding($binding, $class)
+    protected function buildBinding($annotation, $class)
     {
-        return sprintf('$router->model(\'%s\', \'%s\');', $binding, $class) . PHP_EOL;
+        if ($annotation->binder === null) {
+            $method = 'model';
+            $binder = $class;
+        } else {
+            $method = 'bind';
+            $binder = $annotation->binder;
+        }
+        return sprintf('$router->%s(\'%s\', \'%s\');', $method, $annotation->binding, $binder) . PHP_EOL;
     }
 }


### PR DESCRIPTION
If the "uses" parameter is present, the scanner will generate a Route::bind instead of Route::model.  The resolution method is specified in "action" format: "FQCN@method".  If a method isn't specified, the default "bind" method is called on the specified class.  E.g.: 
`@Bind("user", uses="App\User@findBySlug")`

This was a quick and dirty solution to #26.
