### PR TITLE
Making it Laravel 5.1 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,6 @@
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
-        },
-        {
-            "name": "Federico Ferreri",
-            "email": "federico@ferreri.com.ar"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Route Annotations for The Laravel Framework.",
     "keywords": ["framework", "laravel", "annotations"],
     "license": "MIT",
+    "version": "5.1",
     "authors": [
         {
             "name": "Adam Engebretson",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravelcollective/annotations",
+    "name": "fferreri/annotations",
     "description": "Route Annotations for The Laravel Framework.",
     "keywords": ["framework", "laravel", "annotations"],
     "license": "MIT",
@@ -11,19 +11,23 @@
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
+        },
+        {
+            "name": "Federico Ferreri",
+            "email": "federico@ferreri.com.ar"
         }
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/console": "~5.0",
-        "illuminate/filesystem": "~5.0",
-        "illuminate/support": "~5.0",
+        "illuminate/console": "~5.1",
+        "illuminate/filesystem": "~5.1",
+        "illuminate/support": "~5.1",
         "doctrine/annotations": "~1.0",
-        "symfony/console": "2.6.*",
-        "symfony/finder": "2.6.*"
+        "symfony/console": "2.7.*",
+        "symfony/finder": "2.7.*"
     },
     "require-dev": {
-        "illuminate/database": "~5.0",
+        "illuminate/database": "~5.1",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fferreri/annotations",
+    "name": "laravelcollective/annotations",
     "description": "Route Annotations for The Laravel Framework.",
     "keywords": ["framework", "laravel", "annotations"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Route Annotations for The Laravel Framework.",
     "keywords": ["framework", "laravel", "annotations"],
     "license": "MIT",
-    "version": "5.1",
     "authors": [
         {
             "name": "Adam Engebretson",

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,5 @@
 ## Annotations for The Laravel Framework
 
-[![Build Status](https://travis-ci.org/LaravelCollective/annotations.svg)](https://travis-ci.org/LaravelCollective/annotations)
-[![Total Downloads](https://poser.pugx.org/LaravelCollective/annotations/downloads)](https://packagist.org/packages/laravelcollective/annotations)
-[![Latest Stable Version](https://poser.pugx.org/LaravelCollective/annotations/v/stable.svg)](https://packagist.org/packages/laravelcollective/annotations)
-[![Latest Unstable Version](https://poser.pugx.org/LaravelCollective/annotations/v/unstable.svg)](https://packagist.org/packages/laravelcollective/annotations)
-[![License](https://poser.pugx.org/LaravelCollective/annotations/license.svg)](https://packagist.org/packages/laravelcollective/annotations)
+[![Build Status](https://travis-ci.org/LaravelCollective/annotations.svg)](https://travis-ci.org/fferreri/annotations)
 
 Official documentation for Annotations for The Laravel Framework can be found at the [LaravelCollective](http://laravelcollective.com) website.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ## Annotations for The Laravel Framework
 
-[![Build Status](https://travis-ci.org/LaravelCollective/annotations.svg)](https://travis-ci.org/fferreri/annotations)
+[![Build Status](https://travis-ci.org/fferreri/annotations.svg?branch=5.1)](https://travis-ci.org/fferreri/annotations)
 
 Official documentation for Annotations for The Laravel Framework can be found at the [LaravelCollective](http://laravelcollective.com) website.


### PR DESCRIPTION
- I updated composer.json to require the 5.1 Illuminate components as well as the 2.7 Symfony ones. 
- Removed the Travis CI Test for PHP 5.4 since L5.1 requires PHP 5.5.9+

I made this for a project of mine that I needed to update to L5.1. The project is fairly simple but makes use of Annotations for each one of the available routes. So far so good and everything seems to be working fine with the only change I made. 
