### PR TITLE
adding detail information about scanned annotations

### DIFF
--- a/src/Routing/Annotations/EndpointInterface.php
+++ b/src/Routing/Annotations/EndpointInterface.php
@@ -11,6 +11,13 @@ interface EndpointInterface
      */
     public function toRouteDefinition();
 
+	/**
+	 * Get the detail about endpoint that helps to create route definition.
+	 *
+	 * @return array
+	 */
+	public function toRouteDefinitionDetail();
+
     /**
      * Determine if the endpoint has any paths.
      *

--- a/src/Routing/Annotations/MethodEndpoint.php
+++ b/src/Routing/Annotations/MethodEndpoint.php
@@ -83,6 +83,30 @@ class MethodEndpoint implements EndpointInterface
         return implode(PHP_EOL.PHP_EOL, $routes);
     }
 
+	/**
+	 * Get the detail about endpoint that helps to create route definition.
+	 *
+	 * @return array
+	 */
+	public function toRouteDefinitionDetail()
+	{
+		$routes = [];
+
+		foreach ($this->paths as $path) {
+			$routes[] = [
+				'verb' => $path->verb,
+				'path' => $path->path,
+				'uses' => $this->uses,
+				'as' => $path->as,
+				'middleware' => array_merge($this->getClassMiddlewareForPath($path)->all(), $path->middleware, $this->middleware),
+				'where' => $path->where,
+				'domain' => $path->domain,
+			];
+		}
+
+		return $routes;
+	}
+
     /**
      * Get the middleware for the path.
      *

--- a/src/Routing/Annotations/ResourceEndpoint.php
+++ b/src/Routing/Annotations/ResourceEndpoint.php
@@ -142,6 +142,32 @@ class ResourceEndpoint implements EndpointInterface
         return implode(PHP_EOL.PHP_EOL, $routes);
     }
 
+	/**
+	 * Get the detail about endpoint that helps to create route definition.
+	 *
+	 * @return array
+	 */
+	public function toRouteDefinitionDetail()
+	{
+		$routes = [];
+
+		foreach ($this->paths as $path) {
+			$routes[] = [
+				'label' => $this->name . '@' . $path->method,
+				'middleware' => $this->getMiddleware($path),
+				'prefix' => $path->path,
+				'where' => $path->where,
+				'domain' => $path->domain,
+				'name' => $this->name,
+				'resource' => $this->reflection->name,
+				'method' => $path->method,
+				'names' => $this->getNames($path)
+			];
+		}
+
+		return $routes;
+	}
+
     /**
      * Get all of the middleware for the given path.
      *

--- a/src/Routing/Annotations/Scanner.php
+++ b/src/Routing/Annotations/Scanner.php
@@ -42,6 +42,23 @@ class Scanner extends AnnotationScanner
         return trim($output);
     }
 
+	/**
+	 * Give informations about the scanned annotations related to route definition.
+	 *
+	 * @return array
+	 */
+	public function getRouteDefinitionsDetail()
+	{
+		$paths = array();
+		foreach ($this->getEndpointsInClasses($this->getReader()) as $endpoint) {
+			/* @var \Collective\Annotations\Routing\Annotations\MethodEndpoint $endpoint */
+			foreach ($endpoint->toRouteDefinitionDetail() as $path) {
+				$paths[] = $path;
+			}
+		}
+		return $paths;
+	}
+
     /**
      * Scan the directory and generate the route manifest.
      *


### PR DESCRIPTION
Hello,
here is a PR that permit to add some extra and allow people to customize nice stuff.

This PR add information from Scanner (routing) and MethodEndpoint.
* getRouteDefinitionsDetail (Scanner)
* toRouteDefinitionDetail (MethodEndpoint)

This get informations from the annotations but in array instead of string. So it permit some extra like the following.

An example of customization (see #57 ) that this PR allow is : 
inside RouteServiceProvider I have added
~~~php
		$namespace = $this->namespace . '\\';
		Route::macro('scan', function($pathInControllerDirectory) use ($namespace)
		{
			// directory to work in
			$directory = app_path('Http/Controllers/' . $pathInControllerDirectory);
			$classes = app()->make('Collective\Annotations\Filesystem\ClassFinder')->findClasses($directory);

			/* @var \Collective\Annotations\Routing\Annotations\Scanner $scanner */
			$scanner = app()->make('annotations.route.scanner');
			$scanner->setClassesToScan($classes);
			$paths = $scanner->getRouteDefinitionsDetail();

			if (!empty($this->groupStack))
			{
				$group = end($this->groupStack);
				$namespace = isset($group['namespace']) ? ($group['namespace'] . '\\') : '';
			}

			foreach ($paths as $path)
			{
				$action = [
					'uses' => str_replace_last($namespace, '', $path['uses']), // ugly but works!
				    'as' => $path['as'],
				    'middleware' => $path['middleware'],
				    'where' => $path['where'],
				    'domain' => $path['domain'],
				];

				$this->{$path['verb']}($path['path'], $action);
			}
		});
~~~

And so in the route definition we got this :
~~~php
Route::group(['middleware' => 'auth'], function ()
{
	// scan the directory app/Http/Controllers/CS
	Route::scan('CS');
});
~~~

Hope you enjoy it.