### PR TITLE
Bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravelcollective/annotations",
+    "name": "laravelcollective/annotations-edited",
     "description": "Route Annotations for The Laravel Framework.",
     "license": "MIT",
     "homepage": "http://laravelcollective.com",

--- a/src/Console/RouteScanCommand.php
+++ b/src/Console/RouteScanCommand.php
@@ -59,7 +59,7 @@ class RouteScanCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->put($this->getOutputPath(), $this->getRouteDefinitions());
 

--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace Collective\Annotations\Filesystem;


### PR DESCRIPTION
I get an error message because of PHP tag started from second line. Then I fix this.

Error message:

>   [Symfony\Component\Debug\Exception\FatalErrorException]                                                     
>  Namespace declaration statement has to be the very first statement or after any declare call in the script 