### PR TITLE
[5.5] renamed fire() to handle() 

### DIFF
--- a/src/Console/EventScanCommand.php
+++ b/src/Console/EventScanCommand.php
@@ -57,7 +57,7 @@ class EventScanCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->put($this->getOutputPath(), $this->getEventDefinitions());
 

--- a/src/Console/ModelScanCommand.php
+++ b/src/Console/ModelScanCommand.php
@@ -56,7 +56,7 @@ class ModelScanCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->put($this->getOutputPath(), $this->getRouteDefinitions());
 

--- a/src/Console/RouteScanCommand.php
+++ b/src/Console/RouteScanCommand.php
@@ -59,7 +59,7 @@ class RouteScanCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->files->put($this->getOutputPath(), $this->getRouteDefinitions());
 


### PR DESCRIPTION
https://laravel.com/docs/5.5/upgrade

Artisan
The fire Method

Any fire methods present on your Artisan commands should be renamed to handle