### PR TITLE
removed the over space character in the first line

### DIFF
--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace Collective\Annotations\Filesystem;


### PR DESCRIPTION
removed the over space character in the first line on the master branch to fix this issue 
 PHP Fatal error:  Namespace declaration statement has to be the very first statement or after any declare call in the script in /tmp/build_6c677c4b46357b68fb0a1bbd957549e9/vendor/laravelcollective/annotations/src/Filesystem/ClassFinder.php on line 4