### PR TITLE
Remove empty line at the beginning of ClassFinder

### DIFF
--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace Collective\Annotations\Filesystem;


### PR DESCRIPTION
An empty line at the beginning of `ClassFinder.php` is causing problems:

<img width="789" alt="1__term_screen-256color_tmux_new_-s_mon__tmux_" src="https://user-images.githubusercontent.com/129478/35823287-e88a005c-0b13-11e8-8d05-19e7c108c2c5.png">
