### PR TITLE
Add tests for ClassFinder

### DIFF
--- a/tests/Filesystem/ClassFinderTest.php
+++ b/tests/Filesystem/ClassFinderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Collective\Annotations\Filesystem\ClassFinder;
+
+class ClassFinderTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->finder = new ClassFinder();
+    }
+
+    public function testFindClass()
+    {
+        $class = $this->finder->findClass(__DIR__ . '/fixtures/finder/AnyController.php');
+        $this->assertEquals('App\Http\Controllers\AnyController', $class);
+    }
+
+    public function testFindInterfaces()
+    {
+        $class = $this->finder->findClass(__DIR__ . '/fixtures/finder/AnyInterface.php');
+        $this->assertEquals('App\Contracts\AnyInterface', $class);
+    }
+
+    public function testFindClasses()
+    {
+        $classes = $this->finder->findClasses(__DIR__ . '/fixtures/finder');
+        $this->assertEquals([
+            'App\Http\Controllers\AnyController',
+            'App\Contracts\AnyInterface',
+        ], $classes);
+    }
+}

--- a/tests/Filesystem/fixtures/finder/AnyController.php
+++ b/tests/Filesystem/fixtures/finder/AnyController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class AnyController
+{
+}

--- a/tests/Filesystem/fixtures/finder/AnyInterface.php
+++ b/tests/Filesystem/fixtures/finder/AnyInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Contracts;
+
+interface AnyInterface
+{
+}


### PR DESCRIPTION
Adds tests for the new ClassFinder. This will also help catch errors like the one fixed in PR #71 