### PR TITLE
 Fix testFindClasses test

### DIFF
--- a/src/Routing/Annotations/EndpointInterface.php
+++ b/src/Routing/Annotations/EndpointInterface.php
@@ -11,12 +11,12 @@ interface EndpointInterface
      */
     public function toRouteDefinition();
 
-	/**
-	 * Get the detail about endpoint that helps to create route definition.
-	 *
-	 * @return array
-	 */
-	public function toRouteDefinitionDetail();
+    /**
+     * Get the detail about endpoint that helps to create route definition.
+     *
+     * @return array
+     */
+    public function toRouteDefinitionDetail();
 
     /**
      * Determine if the endpoint has any paths.

--- a/src/Routing/Annotations/MethodEndpoint.php
+++ b/src/Routing/Annotations/MethodEndpoint.php
@@ -83,29 +83,29 @@ class MethodEndpoint implements EndpointInterface
         return implode(PHP_EOL.PHP_EOL, $routes);
     }
 
-	/**
-	 * Get the detail about endpoint that helps to create route definition.
-	 *
-	 * @return array
-	 */
+    /**
+     * Get the detail about endpoint that helps to create route definition.
+     *
+     * @return array
+     */
 	public function toRouteDefinitionDetail()
-	{
-		$routes = [];
+    {
+        $routes = [];
 
-		foreach ($this->paths as $path) {
-			$routes[] = [
-				'verb' => $path->verb,
-				'path' => $path->path,
-				'uses' => $this->uses,
-				'as' => $path->as,
-				'middleware' => array_merge($this->getClassMiddlewareForPath($path)->all(), $path->middleware, $this->middleware),
-				'where' => $path->where,
-				'domain' => $path->domain,
-			];
-		}
+        foreach ($this->paths as $path) {
+            $routes[] = [
+                'verb' => $path->verb,
+                'path' => $path->path,
+                'uses' => $this->uses,
+                'as' => $path->as,
+                'middleware' => array_merge($this->getClassMiddlewareForPath($path)->all(), $path->middleware, $this->middleware),
+                'where' => $path->where,
+                'domain' => $path->domain,
+            ];
+        }
 
-		return $routes;
-	}
+        return $routes;
+    }
 
     /**
      * Get the middleware for the path.

--- a/src/Routing/Annotations/ResourceEndpoint.php
+++ b/src/Routing/Annotations/ResourceEndpoint.php
@@ -142,31 +142,31 @@ class ResourceEndpoint implements EndpointInterface
         return implode(PHP_EOL.PHP_EOL, $routes);
     }
 
-	/**
-	 * Get the detail about endpoint that helps to create route definition.
-	 *
-	 * @return array
-	 */
-	public function toRouteDefinitionDetail()
-	{
-		$routes = [];
+    /**
+     * Get the detail about endpoint that helps to create route definition.
+     *
+     * @return array
+     */
+    public function toRouteDefinitionDetail()
+    {
+        $routes = [];
 
-		foreach ($this->paths as $path) {
-			$routes[] = [
-				'label' => $this->name . '@' . $path->method,
-				'middleware' => $this->getMiddleware($path),
-				'prefix' => $path->path,
-				'where' => $path->where,
-				'domain' => $path->domain,
-				'name' => $this->name,
-				'resource' => $this->reflection->name,
-				'method' => $path->method,
-				'names' => $this->getNames($path)
-			];
-		}
+        foreach ($this->paths as $path) {
+            $routes[] = [
+                'label' => $this->name . '@' . $path->method,
+                'middleware' => $this->getMiddleware($path),
+                'prefix' => $path->path,
+                'where' => $path->where,
+                'domain' => $path->domain,
+                'name' => $this->name,
+                'resource' => $this->reflection->name,
+                'method' => $path->method,
+                'names' => $this->getNames($path)
+            ];
+        }
 
-		return $routes;
-	}
+        return $routes;
+    }
 
     /**
      * Get all of the middleware for the given path.

--- a/src/Routing/Annotations/Scanner.php
+++ b/src/Routing/Annotations/Scanner.php
@@ -42,22 +42,23 @@ class Scanner extends AnnotationScanner
         return trim($output);
     }
 
-	/**
-	 * Give informations about the scanned annotations related to route definition.
-	 *
-	 * @return array
-	 */
-	public function getRouteDefinitionsDetail()
-	{
-		$paths = array();
-		foreach ($this->getEndpointsInClasses($this->getReader()) as $endpoint) {
-			/* @var \Collective\Annotations\Routing\Annotations\MethodEndpoint $endpoint */
-			foreach ($endpoint->toRouteDefinitionDetail() as $path) {
-				$paths[] = $path;
-			}
-		}
-		return $paths;
-	}
+    /**
+     * Give information about the scanned annotations related to route definition.
+     *
+     * @return array
+     */
+    public function getRouteDefinitionsDetail()
+    {
+        $paths = array();
+        foreach ($this->getEndpointsInClasses($this->getReader()) as $endpoint) {
+            /* @var \Collective\Annotations\Routing\Annotations\MethodEndpoint $endpoint */
+            foreach ($endpoint->toRouteDefinitionDetail() as $path) {
+                $paths[] = $path;
+            }
+        }
+
+        return $paths;
+    }
 
     /**
      * Scan the directory and generate the route manifest.

--- a/tests/Filesystem/ClassFinderTest.php
+++ b/tests/Filesystem/ClassFinderTest.php
@@ -25,8 +25,8 @@ class ClassFinderTest extends PHPUnit_Framework_TestCase
     {
         $classes = $this->finder->findClasses(__DIR__ . '/fixtures/finder');
         $this->assertEquals([
-            'App\Http\Controllers\AnyController',
             'App\Contracts\AnyInterface',
+            'App\Http\Controllers\AnyController',
         ], $classes);
     }
 }

--- a/tests/Filesystem/ClassFinderTest.php
+++ b/tests/Filesystem/ClassFinderTest.php
@@ -24,6 +24,7 @@ class ClassFinderTest extends PHPUnit_Framework_TestCase
     public function testFindClasses()
     {
         $classes = $this->finder->findClasses(__DIR__ . '/fixtures/finder');
+        sort($classes);
         $this->assertEquals([
             'App\Contracts\AnyInterface',
             'App\Http\Controllers\AnyController',

--- a/tests/Routing/RoutingAnnotationScannerTest.php
+++ b/tests/Routing/RoutingAnnotationScannerTest.php
@@ -31,14 +31,14 @@ class RoutingAnnotationScannerTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(trim(file_get_contents(__DIR__.'/results/annotation-any.php')), $definition);
 	}
 
-	public function testAnyAnnotationDetail()
-	{
-		require_once __DIR__.'/fixtures/annotations/AnyController.php';
-		$scanner = $this->makeScanner(['App\Http\Controllers\AnyController']);
+    public function testAnyAnnotationDetail()
+    {
+        require_once __DIR__.'/fixtures/annotations/AnyController.php';
+        $scanner = $this->makeScanner(['App\Http\Controllers\AnyController']);
 
-		$routeDetail = $scanner->getRouteDefinitionsDetail();
-		$this->assertEquals(include __DIR__ . '/results/route-detail-any.php', $routeDetail);
-	}
+        $routeDetail = $scanner->getRouteDefinitionsDetail();
+        $this->assertEquals(include __DIR__ . '/results/route-detail-any.php', $routeDetail);
+    }
 
     /**
      * Construct a route annotation scanner.

--- a/tests/Routing/results/route-detail-any.php
+++ b/tests/Routing/results/route-detail-any.php
@@ -1,13 +1,13 @@
 <?php
 
 return [
-	[
-		'verb' => 'any',
-		'path' => 'my-any-route',
-		'uses' => 'App\\Http\\Controllers\\AnyController@anyAnnotations',
-		'as' => null,
-		'middleware' => [],
-		'where' => [],
-		'domain' => null,
-	],
+    [
+        'verb' => 'any',
+        'path' => 'my-any-route',
+        'uses' => 'App\\Http\\Controllers\\AnyController@anyAnnotations',
+        'as' => null,
+        'middleware' => [],
+        'where' => [],
+        'domain' => null,
+    ],
 ];

--- a/tests/Routing/results/route-detail-basic.php
+++ b/tests/Routing/results/route-detail-basic.php
@@ -1,62 +1,62 @@
 <?php
 
 return [
-	[
-		'verb' => 'put',
-		'path' => 'more/{id}',
-		'uses' => 'App\\Http\\Controllers\\BasicController@doMore',
-		'as' => null,
-		'middleware' =>
-			[
-				0 => 'FooMiddleware',
-				1 => 'BarMiddleware',
-				2 => 'QuxMiddleware',
-			],
-		'where' =>
-			[
-				'id' => 'regex',
-			],
-		'domain' => '{id}.account.com',
-	],
-	[
-		'label' => 'foobar/photos@index',
-		'middleware' =>
-			[
-				0 => 'FooMiddleware',
-				1 => 'BarMiddleware',
-				2 => 'BoomMiddleware',
-				3 => 'BazMiddleware',
-			],
-		'prefix' => null,
-		'where' =>
-			[
-				'id' => 'regex',
-			],
-		'domain' => '{id}.account.com',
-		'name' => 'foobar/photos',
-		'resource' => 'App\\Http\\Controllers\\BasicController',
-		'method' => 'index',
-		'names' =>
-			[
-				'index' => 'index.name',
-			],
-	],
-	[
-		'label' => 'foobar/photos@update',
-		'middleware' =>
-			[
-				0 => 'FooMiddleware',
-				1 => 'BarMiddleware',
-			],
-		'prefix' => null,
-		'where' =>
-			[
-				'id' => 'regex',
-			],
-		'domain' => '{id}.account.com',
-		'name' => 'foobar/photos',
-		'resource' => 'App\\Http\\Controllers\\BasicController',
-		'method' => 'update',
-		'names' => [],
-	],
+    [
+        'verb' => 'put',
+        'path' => 'more/{id}',
+        'uses' => 'App\\Http\\Controllers\\BasicController@doMore',
+        'as' => null,
+        'middleware' =>
+            [
+                0 => 'FooMiddleware',
+                1 => 'BarMiddleware',
+                2 => 'QuxMiddleware',
+            ],
+        'where' =>
+            [
+                'id' => 'regex',
+            ],
+        'domain' => '{id}.account.com',
+    ],
+    [
+        'label' => 'foobar/photos@index',
+        'middleware' =>
+            [
+                0 => 'FooMiddleware',
+                1 => 'BarMiddleware',
+                2 => 'BoomMiddleware',
+                3 => 'BazMiddleware',
+            ],
+        'prefix' => null,
+        'where' =>
+            [
+                'id' => 'regex',
+            ],
+        'domain' => '{id}.account.com',
+        'name' => 'foobar/photos',
+        'resource' => 'App\\Http\\Controllers\\BasicController',
+        'method' => 'index',
+        'names' =>
+            [
+                'index' => 'index.name',
+            ],
+    ],
+    [
+        'label' => 'foobar/photos@update',
+        'middleware' =>
+            [
+                0 => 'FooMiddleware',
+                1 => 'BarMiddleware',
+            ],
+        'prefix' => null,
+        'where' =>
+            [
+                'id' => 'regex',
+            ],
+        'domain' => '{id}.account.com',
+        'name' => 'foobar/photos',
+        'resource' => 'App\\Http\\Controllers\\BasicController',
+        'method' => 'update',
+        'names' => [],
+    ],
 ];


### PR DESCRIPTION
This test is actually failing in master currently, as well as the 5.6 branch if that change is cherry-picked into that branch.
The concern with this test failing was that the order of the returned classes was important, but given that the updated order is the current behaviour of both master and the 5.6 branch it can't actually be a problem to just switch the order in the test. Presumably this relates to update in the Symfony finder since this test was created originally.

The other changes are just a product of my OCD, updating the tabs in one of the changes that made it into master into spaces to match the rest of the file.