### PR TITLE
Add additional test for where annotation as part of single route Get

### DIFF
--- a/tests/Routing/RoutingAnnotationScannerTest.php
+++ b/tests/Routing/RoutingAnnotationScannerTest.php
@@ -40,14 +40,23 @@ class RoutingAnnotationScannerTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(include __DIR__ . '/results/route-detail-any.php', $routeDetail);
 	}
 
-	public function testWhereAnnotation()
-	{
-		require_once __DIR__.'/fixtures/annotations/WhereController.php';
-		$scanner = $this->makeScanner(['App\Http\Controllers\WhereController']);
+    public function testWhereAnnotation()
+    {
+        require_once __DIR__.'/fixtures/annotations/WhereController.php';
+        $scanner = $this->makeScanner(['App\Http\Controllers\WhereController']);
 
-		$routeDetail = $scanner->getRouteDefinitionsDetail();
-		$this->assertEquals(include __DIR__ . '/results/route-detail-where.php', $routeDetail);
-	}
+        $definition = $scanner->getRouteDefinitions();
+        $this->assertEquals(trim(file_get_contents(__DIR__.'/results/annotation-where.php')), $definition);
+    }
+
+    public function testWhereAnnotationDetail()
+    {
+        require_once __DIR__.'/fixtures/annotations/WhereController.php';
+        $scanner = $this->makeScanner(['App\Http\Controllers\WhereController']);
+
+        $routeDetail = $scanner->getRouteDefinitionsDetail();
+        $this->assertEquals(include __DIR__ . '/results/route-detail-where.php', $routeDetail);
+    }
 
     /**
      * Construct a route annotation scanner.

--- a/tests/Routing/fixtures/annotations/WhereController.php
+++ b/tests/Routing/fixtures/annotations/WhereController.php
@@ -11,4 +11,11 @@ class WhereController
     public function whereAnnotations()
     {
     }
+
+    /**
+     * @Get("/{key}", where={"key": "value"})
+     */
+    public function getWhereAnnotations()
+    {
+    }
 }

--- a/tests/Routing/results/annotation-where.php
+++ b/tests/Routing/results/annotation-where.php
@@ -1,0 +1,16 @@
+$router->any('/', [
+	'uses' => 'App\Http\Controllers\WhereController@whereAnnotations',
+	'as' => NULL,
+	'middleware' => [],
+	'where' => ['key' => 'value'],
+	'domain' => NULL,
+]);
+
+$router->get('{key}', [
+	'uses' => 'App\Http\Controllers\WhereController@getWhereAnnotations',
+	'as' => NULL,
+	'middleware' => [],
+	'where' => ['key' => 'value'],
+	'domain' => NULL,
+]);
+

--- a/tests/Routing/results/route-detail-where.php
+++ b/tests/Routing/results/route-detail-where.php
@@ -1,14 +1,23 @@
 <?php
 
 return [
-	[
-		'verb' => 'any',
-		'path' => '/',
-		'uses' => 'App\\Http\\Controllers\\WhereController@whereAnnotations',
-		'as' => null,
-		'middleware' => [],
-		'where' => ["key" => "value"],
-		'domain' => null,
-	],
+    [
+        'verb' => 'any',
+        'path' => '/',
+        'uses' => 'App\\Http\\Controllers\\WhereController@whereAnnotations',
+        'as' => null,
+        'middleware' => [],
+        'where' => ["key" => "value"],
+        'domain' => null,
+    ],
+    [
+        'verb' => 'get',
+        'path' => '{key}',
+        'uses' => 'App\\Http\\Controllers\\WhereController@getWhereAnnotations',
+        'as' => null,
+        'middleware' => [],
+        'where' => ["key" => "value"],
+        'domain' => null,
+    ],
 ];
 


### PR DESCRIPTION
Ensures both the detail and standard route definition scans output the expected result.
Also checks both the following methods of adding a where clause:
```
   /**
     * @Get("/{key}", where={"key": "value"})
     */
```
```
    /**
     * @Any("/")
     * @Where(key="value")
     */
```