### PR TITLE
Adding a new option to ignore the inherit prefix in @Controller annotation

### DIFF
--- a/src/Routing/Annotations/Annotations/Controller.php
+++ b/src/Routing/Annotations/Annotations/Controller.php
@@ -34,7 +34,9 @@ class Controller extends Annotation
     protected function prefixEndpoints(EndpointCollection $endpoints)
     {
         foreach ($endpoints->getAllPaths() as $path) {
-            $path->path = $this->trimPath($this->prefix, $path->path);
+            if(!$path->no_prefix) {
+                $path->path = $this->trimPath($this->prefix, $path->path);
+            }
         }
     }
 

--- a/src/Routing/Annotations/Annotations/Controller.php
+++ b/src/Routing/Annotations/Annotations/Controller.php
@@ -34,7 +34,7 @@ class Controller extends Annotation
     protected function prefixEndpoints(EndpointCollection $endpoints)
     {
         foreach ($endpoints->getAllPaths() as $path) {
-            if(!$path->no_prefix) {
+            if (!$path->no_prefix) {
                 $path->path = $this->trimPath($this->prefix, $path->path);
             }
         }

--- a/src/Routing/Annotations/Annotations/Middleware.php
+++ b/src/Routing/Annotations/Annotations/Middleware.php
@@ -33,6 +33,16 @@ class Middleware extends Annotation
     {
         foreach ($endpoints as $endpoint) {
             foreach ((array) $this->value as $middleware) {
+                if($multipleMiddlewares = explode(',', $middleware)){
+                    $middleware = '';
+                    $nbMiddlewares = count($multipleMiddlewares)-1;
+
+                    for($i=0; $i<=$nbMiddlewares; ++$i) {
+                        $middleware .= $i > 0 ? "'" : '';
+                        $middleware .= str_replace(' ', '', $multipleMiddlewares[$i]);
+                        $middleware .= $i < $nbMiddlewares  ? "', " : '';
+                    }
+                }
                 $endpoint->classMiddleware[] = [
                     'name' => $middleware, 'only' => (array) $this->only, 'except' => (array) $this->except,
                 ];

--- a/src/Routing/Annotations/Annotations/Middleware.php
+++ b/src/Routing/Annotations/Annotations/Middleware.php
@@ -33,16 +33,6 @@ class Middleware extends Annotation
     {
         foreach ($endpoints as $endpoint) {
             foreach ((array) $this->value as $middleware) {
-                if($multipleMiddlewares = explode(',', $middleware)){
-                    $middleware = '';
-                    $nbMiddlewares = count($multipleMiddlewares)-1;
-
-                    for($i=0; $i<=$nbMiddlewares; ++$i) {
-                        $middleware .= $i > 0 ? "'" : '';
-                        $middleware .= str_replace(' ', '', $multipleMiddlewares[$i]);
-                        $middleware .= $i < $nbMiddlewares  ? "', " : '';
-                    }
-                }
                 $endpoint->classMiddleware[] = [
                     'name' => $middleware, 'only' => (array) $this->only, 'except' => (array) $this->except,
                 ];

--- a/src/Routing/Annotations/Annotations/Route.php
+++ b/src/Routing/Annotations/Annotations/Route.php
@@ -15,7 +15,7 @@ abstract class Route extends Annotation
     {
         $endpoint->addPath(new Path(
             strtolower(class_basename(get_class($this))), $this->domain, $this->value,
-            $this->as, (array) $this->middleware, (array) $this->where
+            $this->as, (array) $this->middleware, (array) $this->where, $this->no_prefix
         ));
     }
 }

--- a/src/Routing/Annotations/Path.php
+++ b/src/Routing/Annotations/Path.php
@@ -10,6 +10,7 @@ class Path extends AbstractPath
      * @var string
      */
     public $as;
+    public $no_prefix;
 
     /**
      * Create a new Route Path instance.
@@ -23,7 +24,7 @@ class Path extends AbstractPath
      *
      * @return void
      */
-    public function __construct($verb, $domain, $path, $as, $middleware = [], $where = [])
+    public function __construct($verb, $domain, $path, $as, $middleware = [], $where = [], $no_prefix=false)
     {
         $this->as = $as;
         $this->verb = $verb;
@@ -31,5 +32,6 @@ class Path extends AbstractPath
         $this->domain = $domain;
         $this->middleware = $middleware;
         $this->path = $path == '/' ? '/' : trim($path, '/');
+        $this->no_prefix = $no_prefix;
     }
 }

--- a/tests/Routing/RoutingAnnotationScannerTest.php
+++ b/tests/Routing/RoutingAnnotationScannerTest.php
@@ -30,6 +30,15 @@ class RoutingAnnotationScannerTest extends TestCase
 
 		$definition = str_replace(PHP_EOL, "\n", $scanner->getRouteDefinitions());
 		$this->assertEquals(trim(file_get_contents(__DIR__.'/results/annotation-any.php')), $definition);
+    }
+    
+    public function testPrefixAnnotation()
+	{
+		require_once __DIR__.'/fixtures/annotations/PrefixController.php';
+		$scanner = $this->makeScanner(['App\Http\Controllers\PrefixController']);
+
+		$definition = str_replace(PHP_EOL, "\n", $scanner->getRouteDefinitions());
+		$this->assertEquals(trim(file_get_contents(__DIR__.'/results/annotation-prefix.php')), $definition);
 	}
 
     public function testAnyAnnotationDetail()

--- a/tests/Routing/fixtures/annotations/PrefixController.php
+++ b/tests/Routing/fixtures/annotations/PrefixController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+/**
+ * @Controller(prefix="/any-prefix")
+ */
+
+
+class PrefixController
+{
+    /**
+     * @Get("route-with-prefix", as="route.with.prefix")
+    */
+    public function withPrefixAnnotations()
+    {
+    }
+
+    /**
+     * @Get("route-without-prefix", as="route.without.prefix", no_prefix="true")
+    */
+    public function withoutPrefixAnnotations()
+    {
+    }
+}

--- a/tests/Routing/results/annotation-prefix.php
+++ b/tests/Routing/results/annotation-prefix.php
@@ -1,0 +1,15 @@
+$router->get('any-prefix/route-with-prefix', [
+	'uses' => 'App\Http\Controllers\PrefixController@withPrefixAnnotations',
+	'as' => 'route.with.prefix',
+	'middleware' => [],
+	'where' => [],
+	'domain' => NULL,
+]);
+
+$router->get('route-without-prefix', [
+	'uses' => 'App\Http\Controllers\PrefixController@withoutPrefixAnnotations',
+	'as' => 'route.without.prefix',
+	'middleware' => [],
+	'where' => [],
+	'domain' => NULL,
+]);


### PR DESCRIPTION
If you have this prefix at the top of your class:

` * @Controller(prefix="/your/prefix")`

You can avoid it using no_prefix parameter in your routes annotations:

`* @Get("/list", as="your.route.index", no_prefix="true")`

On this way, the route gonna be /list instead /your/prefix/list