### PR TITLE
Fix scan syntax error

### DIFF
--- a/src/AnnotationsServiceProvider.php
+++ b/src/AnnotationsServiceProvider.php
@@ -291,7 +291,7 @@ class AnnotationsServiceProvider extends ServiceProvider
         $scanner->setClassesToScan($scans);
 
         file_put_contents(
-          $this->finder->getScannedEventsPath(), '<?php '.$scanner->getEventDefinitions()
+          $this->finder->getScannedEventsPath(), '<?php '.PHP_EOL.PHP_EOL.$scanner->getEventDefinitions().PHP_EOL
         );
     }
 
@@ -343,7 +343,7 @@ class AnnotationsServiceProvider extends ServiceProvider
         $scanner->setClassesToScan($scans);
 
         file_put_contents(
-            $this->finder->getScannedRoutesPath(), '<?php '.$scanner->getRouteDefinitions()
+            $this->finder->getScannedRoutesPath(), '<?php '.PHP_EOL.PHP_EOL.$scanner->getRouteDefinitions().PHP_EOL
         );
     }
 
@@ -397,7 +397,7 @@ class AnnotationsServiceProvider extends ServiceProvider
         $scanner->setClassesToScan($scans);
 
         file_put_contents(
-          $this->finder->getScannedModelsPath(), '<?php '.$scanner->getModelDefinitions()
+          $this->finder->getScannedModelsPath(), '<?php '.PHP_EOL.PHP_EOL.$scanner->getModelDefinitions().PHP_EOL
         );
     }
 


### PR DESCRIPTION
The following error produces a command at the time of practice.
```
$ php artisan route:scan

ParseError
syntax error, unexpected ')', expecting end of file
storage/framework/routes.scanned.php:7
    3|  'as' => NULL,
    4|  'middleware' => [],
    5|  'where' => [],
    6|  'domain' => NULL,
  > 7| ]);
```

The first did not have any problem, but revised it when ```storage/framework/routes.scanned.php``` existed as it became the Perth error because it was the second time, and PHP_EOL did not exist.

PHP 7.2.31