### PR TITLE
PHP 8 & Laravel 8 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
+  - 8.0
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/console": "^6.0",
-        "illuminate/filesystem": "^6.0",
-        "illuminate/support": "^6.0",
+        "php": "^7.3|^8.0",
+        "illuminate/console": "^8.0",
+        "illuminate/filesystem": "^8.0",
+        "illuminate/support": "^8.0",
         "doctrine/annotations": "~1.0"
     },
     "require-dev": {
-        "illuminate/database": "^6.0",
+        "illuminate/database": "^8.0",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="phpunit.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Laravel Annotations Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="phpunit.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Laravel Annotations Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/AnnotationsServiceProvider.php
+++ b/src/AnnotationsServiceProvider.php
@@ -8,7 +8,6 @@ use Collective\Annotations\Console\RouteScanCommand;
 use Collective\Annotations\Database\Eloquent\Annotations\Scanner as ModelScanner;
 use Collective\Annotations\Events\Annotations\Scanner as EventScanner;
 use Collective\Annotations\Routing\Annotations\Scanner as RouteScanner;
-use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Console/RouteScanCommand.php
+++ b/src/Console/RouteScanCommand.php
@@ -3,7 +3,7 @@
 namespace Collective\Annotations\Console;
 
 use Collective\Annotations\AnnotationsServiceProvider;
-use Illuminate\Console\DetectsApplicationNamespace;
+use Collective\Annotations\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/DetectsApplicationNamespace.php
+++ b/src/DetectsApplicationNamespace.php
@@ -1,0 +1,24 @@
+<?php
+namespace Collective\Annotations;
+
+use Illuminate\Container\Container;
+
+/**
+ * Trait DetectsApplicationNamespace
+ *
+ * This got deprecated in Laravel 7, so fastest solution would be to just have this here.
+ *
+ * @package Collective\Annotations
+ */
+trait DetectsApplicationNamespace
+{
+    /**
+     * Get the application namespace.
+     *
+     * @return string
+     */
+    protected function getAppNamespace()
+    {
+        return Container::getInstance()->getNamespace();
+    }
+}

--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -110,7 +110,7 @@ class ClassFinder
      */
     protected function isPartOfNamespace($token)
     {
-        return is_array($token) && ($token[0] == T_STRING || $token[0] == T_NS_SEPARATOR);
+        return is_array($token) && ($token[0] == T_STRING || $token[0] == T_NAME_QUALIFIED);
     }
 
     /**

--- a/src/Filesystem/ClassFinder.php
+++ b/src/Filesystem/ClassFinder.php
@@ -110,7 +110,13 @@ class ClassFinder
      */
     protected function isPartOfNamespace($token)
     {
-        return is_array($token) && ($token[0] == T_STRING || $token[0] == T_NAME_QUALIFIED);
+        /**
+         * T_NAME_QUALIFIED >= PHP 8.0
+         * T_NS_SEPARATOR   <= PHP 8.0
+         */
+        $compare = (defined('T_NAME_QUALIFIED') ? T_NAME_QUALIFIED : T_NS_SEPARATOR);
+
+        return is_array($token) && ($token[0] == T_STRING || $token[0] == $compare);
     }
 
     /**

--- a/src/NamespaceToPathConverterTrait.php
+++ b/src/NamespaceToPathConverterTrait.php
@@ -2,7 +2,6 @@
 
 namespace Collective\Annotations;
 
-use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Support\Facades\App;
 
 trait NamespaceToPathConverterTrait

--- a/tests/AnnotationsServiceProviderTest.php
+++ b/tests/AnnotationsServiceProviderTest.php
@@ -27,7 +27,7 @@ class AnnotationsServiceProviderTest extends TestCase
 
     public function testConvertNamespaceToPath()
     {
-        $this->provider = new AnnotationsServiceProviderAppNamespaceStub($this->app);
+        $this->provider = new AnnotationsServiceProvider($this->app);
         $class = 'App\\Foo';
 
         $result = $this->provider->convertNamespaceToPath($class);
@@ -41,7 +41,7 @@ class AnnotationsServiceProviderTest extends TestCase
             ->andReturn('Foo\\');
         Container::setInstance($this->app);
 
-        $this->provider = new AnnotationsServiceProviderAppNamespaceStub($this->app);
+        $this->provider = new AnnotationsServiceProvider($this->app);
         $class = 'App\\Foo';
 
         $result = $this->provider->convertNamespaceToPath($class);
@@ -53,7 +53,7 @@ class AnnotationsServiceProviderTest extends TestCase
     {
         $this->app->shouldReceive('getNamespace')->once()
             ->andReturn('App\\');
-        $this->provider = new AnnotationsServiceProviderAppNamespaceStub($this->app);
+        $this->provider = new AnnotationsServiceProvider($this->app);
         Container::setInstance($this->app);
 
         $this->app->shouldReceive('make')
@@ -67,15 +67,5 @@ class AnnotationsServiceProviderTest extends TestCase
         $results = $this->provider->getClassesFromNamespace('App\\Base', 'path/to/app');
 
         $this->assertEquals(['classes'], $results);
-    }
-}
-
-class AnnotationsServiceProviderAppNamespaceStub extends AnnotationsServiceProvider
-{
-    public $appNamespace = 'App';
-
-    public function getAppNamespace()
-    {
-        return $this->appNamespace;
     }
 }


### PR DESCRIPTION
This is ready for review.

What has changed:
- Added php `8.0` to Travis build file
- Changed composer.json to require either php 7.3 or 8.0
- Upgrade PHPUnit to v9
- Added the deprecated trait to the codebase (as it is a simple one) to avoid multiple calls to the Container instance `getNamespace` method
- Fixed the method `isPartOfNamespace` to consider constant either from PHP 8 or 7
- Fixed tests